### PR TITLE
fix clang warnings

### DIFF
--- a/src/form.h
+++ b/src/form.h
@@ -115,7 +115,7 @@ class FormGroup: public FormField
     }
 
 #if defined(DEBUG_WINDOWS)
-    std::string getName() const override
+    virtual std::string getName() const override
     {
       return "FormGroup";
     }


### PR DESCRIPTION
Only virtual methods can be overridden, and needs to marked as such. (sorry for nit-picking, but it's clang's fault :-D)