### PR TITLE
Use 16bit colors in LcdFlags instead of palette index

### DIFF
--- a/src/bitmapbuffer.cpp
+++ b/src/bitmapbuffer.cpp
@@ -420,19 +420,16 @@ void BitmapBuffer::drawFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, ui
   else {
     // SOLID
 
-
     // TODO: can this be done in one step? (see drawBitmapPattern())
     
     // Use the DMA2D to blend a scratch buffer filled with overlay color
     BitmapBuffer scratch(BMP_ARGB4444, LCD_W, LCD_H, lcdGetScratchBuffer());
-    RGB_SPLIT(COLOR_VAL(flags), r, g, b);
 
-    LcdFlags flags =
-      uint32_t(ARGB((OPACITY_MAX - opacity) << 4, r << 3, g << 2, b << 3))
-      << 16;
+    RGB_SPLIT(COLOR_VAL(flags), r, g, b);
+    pixel_t color_argb = ARGB((OPACITY_MAX - opacity) << 4, r << 3, g << 2, b << 3);
 
     // Fill the buffer
-    scratch.drawSolidFilledRect(0, 0, w, h, flags);
+    scratch.drawSolidFilledRect(0, 0, w, h, color_argb << 16);
 
     // And blend
     drawBitmapAbs(x, y, &scratch, 0, 0, w, h);
@@ -760,7 +757,6 @@ void BitmapBuffer::drawMask(coord_t x, coord_t y, const BitmapBuffer * mask, con
 //  drawAlphaPixel(bmp[x][y], pixel(x,y), color)
 //
 //
-void DMACopyAlphaMask(uint16_t * dest, uint16_t destw, uint16_t desth, uint16_t x, uint16_t y, const uint8_t * src, uint16_t srcw, uint16_t srch, uint16_t srcx, uint16_t srcy, uint16_t w, uint16_t h, uint16_t bg_color);
 //
 void BitmapBuffer::drawBitmapPattern(coord_t x, coord_t y, const uint8_t * bmp, LcdFlags flags, coord_t offset, coord_t width)
 {

--- a/src/bitmapbuffer.cpp
+++ b/src/bitmapbuffer.cpp
@@ -683,6 +683,9 @@ void BitmapBuffer::drawMask(coord_t x, coord_t y, const BitmapBuffer * mask, Lcd
   if (y >= ymax || x >= xmax || width <= 0 || x + width < xmin || y + height < ymin)
     return;
 
+  // TODO: This should be doable the same way as with
+  //       drawBitmapPattern() (just with ARGB as input).
+  //
   pixel_t color = COLOR_VAL(flags);
 
   for (coord_t row = 0; row < height; row++) {
@@ -730,15 +733,9 @@ void BitmapBuffer::drawMask(coord_t x, coord_t y, const BitmapBuffer * mask, con
     return;
 
 
-  // TODO:
+  // TODO: This should be doable the same way as with
+  //       drawBitmapPattern() (just with ARGB as input).
   //
-  // Try with DMA2D:
-  // - [ Fill  ] copy scrBitmap into scratch buffer
-  // - ( +- [ Convert ] convert mask into ARGB4444 )
-  // - [ Blend ] draw mask as alpha(ARGB4444) into scratch buffer
-  // - [ Blend ] blend into current buffer
-  //
-  
   for (coord_t row = 0; row < height; row++) {
     if (y + row < ymin || y + row >= ymax)
       continue;

--- a/src/bitmapbuffer.h
+++ b/src/bitmapbuffer.h
@@ -183,54 +183,10 @@ class RLEBitmap:
   public BitmapBufferBase<uint16_t>
 {
   public:
-    RLEBitmap(uint8_t format, const uint8_t* rle_data) :
-      BitmapBufferBase<uint16_t>(format, 0, 0, nullptr)
-    {
-      _width = *((uint16_t *)rle_data);
-      _height = *(((uint16_t *)rle_data)+1);
-      uint32_t pixels = _width * _height;
-      data = (uint16_t*)malloc(align32(pixels * sizeof(uint16_t)));
-      decode((uint8_t *)data, pixels * sizeof(uint16_t), rle_data+4);
-      data_end = data + pixels;
-    }
+    RLEBitmap(uint8_t format, const uint8_t* rle_data);
+    ~RLEBitmap();
 
-    ~RLEBitmap()
-    {
-      free(data);
-    }
-
-    static int decode(uint8_t * dest, unsigned int destSize, const uint8_t * src)
-    {
-      uint8_t prevByte = 0;
-      bool prevByteValid = false;
-
-      const uint8_t * destEnd = dest + destSize;
-      uint8_t * d = dest;
-
-      while (d < destEnd) {
-        uint8_t byte = *src++;
-        *d++ = byte;
-
-        if (prevByteValid && byte == prevByte) {
-          uint8_t count = *src++;
-
-          if (d + count > destEnd) {
-            TRACE("rle_decode_8bit: destination overflow!\n");
-            return -1;
-          }
-
-          memset(d, byte, count);
-          d += count;
-          prevByteValid = false;
-        }
-        else {
-          prevByte = byte;
-          prevByteValid = true;
-        }
-      }
-
-      return d - dest;
-    }
+    static int decode(uint8_t * dest, unsigned int destSize, const uint8_t * src);
 };
 
 class BitmapBuffer: public BitmapBufferBase<pixel_t>
@@ -242,32 +198,10 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
 #endif
 
   public:
-    BitmapBuffer(uint8_t format, uint16_t width, uint16_t height):
-      BitmapBufferBase<uint16_t>(format, width, height, nullptr),
-      dataAllocated(true)
-#if defined(DEBUG)
-      , leakReported(false)
-#endif
-    {
-      data = (uint16_t *)malloc(align32(width * height * sizeof(uint16_t)));
-      data_end = data + (width * height);
-    }
+    BitmapBuffer(uint8_t format, uint16_t width, uint16_t height);
+    BitmapBuffer(uint8_t format, uint16_t width, uint16_t height, uint16_t * data);
 
-    BitmapBuffer(uint8_t format, uint16_t width, uint16_t height, uint16_t * data):
-      BitmapBufferBase<uint16_t>(format, width, height, data),
-      dataAllocated(false)
-#if defined(DEBUG)
-      , leakReported(false)
-#endif
-    {
-    }
-
-    ~BitmapBuffer()
-    {
-      if (dataAllocated) {
-        free(data);
-      }
-    }
+    ~BitmapBuffer();
 
     inline void setFormat(uint8_t format)
     {
@@ -384,32 +318,10 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
     coord_t drawNumber(coord_t x, coord_t y, int32_t val, LcdFlags flags = 0, uint8_t len = 0, const char * prefix = nullptr, const char * suffix = nullptr);
 
     template<class T>
-    void drawBitmap(coord_t x, coord_t y, const T * bmp, coord_t srcx = 0, coord_t srcy = 0, coord_t srcw = 0, coord_t srch = 0, float scale = 0)
-    {
-      if (!data || !bmp)
-        return;
-
-      APPLY_OFFSET();
-
-      if (x >= xmax || y >= ymax)
-        return;
-
-      drawBitmapAbs<T>(x, y, bmp, srcx, srcy, srcw, srch, scale);
-    }
+    void drawBitmap(coord_t x, coord_t y, const T * bmp, coord_t srcx = 0, coord_t srcy = 0, coord_t srcw = 0, coord_t srch = 0, float scale = 0);
 
     template<class T>
-    void drawScaledBitmap(const T * bitmap, coord_t x, coord_t y, coord_t w, coord_t h)
-    {
-      if (bitmap) {
-        float vscale = float(h) / bitmap->height();
-        float hscale = float(w) / bitmap->width();
-        float scale = vscale < hscale ? vscale : hscale;
-
-        int xshift = (w - (bitmap->width() * scale)) / 2;
-        int yshift = (h - (bitmap->height() * scale)) / 2;
-        drawBitmap(x + xshift, y + yshift, bitmap, 0, 0, 0, 0, scale);
-      }
-    }
+    void drawScaledBitmap(const T * bitmap, coord_t x, coord_t y, coord_t w, coord_t h);
 
     BitmapBuffer * horizontalFlip() const;
 
@@ -455,97 +367,10 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       return data && h > 0 && w > 0;
     }
 
-    template<class T>
-    void drawBitmapAbs(coord_t x, coord_t y, const T * bmp, coord_t srcx = 0, coord_t srcy = 0, coord_t srcw = 0, coord_t srch = 0, float scale = 0)
-    {
-      coord_t bmpw = bmp->width();
-      coord_t bmph = bmp->height();
-
-      if (srcw == 0)
-        srcw = bmpw;
-      if (srch == 0)
-        srch = bmph;
-      if (srcx + srcw > bmpw)
-        srcw = bmpw - srcx;
-      if (srcy + srch > bmph)
-        srch = bmph - srcy;
-
-      if (scale == 0) {
-        if (x < xmin) {
-          srcw += x - xmin;
-          srcx -= x - xmin;
-          x = xmin;
-        }
-        if (y < ymin) {
-          srch += y - ymin;
-          srcy -= y - ymin;
-          y = ymin;
-        }
-        if (x + srcw > xmax) {
-          srcw = xmax - x;
-        }
-        if (y + srch > ymax) {
-          srch = ymax - y;
-        }
-      }
-      else {
-        if (x < xmin) {
-          srcw += (x - xmin) / scale;
-          srcx -= (x - xmin) / scale;
-          x = xmin;
-        }
-        if (y < ymin) {
-          srch += (y - ymin) / scale;
-          srcy -= (y - ymin) / scale;
-          y = ymin;
-        }
-        if (x + srcw * scale > xmax) {
-          srcw = (xmax - x) / scale;
-        }
-        if (y + srch * scale > ymax) {
-          srch = (ymax - y) / scale;
-        }
-      }
-
-      if (srcw <= 0 || srch <= 0) {
-        return;
-      }
-
-      if (scale == 0) {
-        if (bmp->getFormat() == BMP_ARGB4444) {
-          DMACopyAlphaBitmap(data, _width, _height, x, y, bmp->getData(), bmpw, bmph, srcx, srcy, srcw, srch);
-        }
-        else {
-          DMACopyBitmap(data, _width, _height, x, y, bmp->getData(), bmpw, bmph, srcx, srcy, srcw, srch);
-        }
-      }
-      else {
-        int scaledw = srcw * scale;
-        int scaledh = srch * scale;
-
-        if (x + scaledw > _width)
-          scaledw = _width - x;
-        if (y + scaledh > _height)
-          scaledh = _height - y;
-
-        for (int i = 0; i < scaledh; i++) {
-          pixel_t * p = getPixelPtrAbs(x, y + i);
-          const pixel_t * qstart = bmp->getPixelPtrAbs(srcx, srcy + int(i / scale));
-          for (int j = 0; j < scaledw; j++) {
-            const pixel_t * q = qstart;
-            MOVE_PIXEL_RIGHT(q, int(j / scale));
-            if (bmp->getFormat() == BMP_ARGB4444) {
-              ARGB_SPLIT(*q, a, r, g, b);
-              drawAlphaPixel(p, a, RGB_JOIN(r<<1, g<<2, b<<1));
-            }
-            else {
-              drawPixel(p, *q);
-            }
-            MOVE_TO_NEXT_RIGHT_PIXEL(p);
-          }
-        }
-      }
-    }
+    template <class T>
+    void drawBitmapAbs(coord_t x, coord_t y, const T* bmp, coord_t srcx = 0,
+                       coord_t srcy = 0, coord_t srcw = 0, coord_t srch = 0,
+                       float scale = 0);
 
     uint8_t drawChar(coord_t x, coord_t y, const uint8_t * font, const uint16_t * spec, unsigned int index, LcdFlags flags);
 

--- a/src/bitmapbuffer.h
+++ b/src/bitmapbuffer.h
@@ -394,6 +394,70 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       if (x >= xmax || y >= ymax)
         return;
 
+      drawBitmapAbs<T>(x, y, bmp, srcx, srcy, srcw, srch, scale);
+    }
+
+    template<class T>
+    void drawScaledBitmap(const T * bitmap, coord_t x, coord_t y, coord_t w, coord_t h)
+    {
+      if (bitmap) {
+        float vscale = float(h) / bitmap->height();
+        float hscale = float(w) / bitmap->width();
+        float scale = vscale < hscale ? vscale : hscale;
+
+        int xshift = (w - (bitmap->width() * scale)) / 2;
+        int yshift = (h - (bitmap->height() * scale)) / 2;
+        drawBitmap(x + xshift, y + yshift, bitmap, 0, 0, 0, 0, scale);
+      }
+    }
+
+    BitmapBuffer * horizontalFlip() const;
+
+    BitmapBuffer * verticalFlip() const;
+
+    BitmapBuffer * invertMask() const;
+
+  protected:
+    static BitmapBuffer * load_bmp(const char * filename);
+    static BitmapBuffer * load_stb(const char * filename);
+
+    inline bool applyClippingRect(coord_t & x, coord_t & y, coord_t & w, coord_t & h) const
+    {
+      if (h < 0) {
+        y += h;
+        h = -h;
+      }
+
+      if (w < 0) {
+        x += w;
+        w = -w;
+      }
+
+      if (x >= xmax || y >= ymax)
+        return false;
+
+      if (y < ymin) {
+        h += y - ymin;
+        y = ymin;
+      }
+
+      if (x < xmin) {
+        w += x - xmin;
+        x = xmin;
+      }
+
+      if (y + h > ymax)
+        h = ymax - y;
+
+      if (x + w > xmax)
+        w = xmax - x;
+
+      return data && h > 0 && w > 0;
+    }
+
+    template<class T>
+    void drawBitmapAbs(coord_t x, coord_t y, const T * bmp, coord_t srcx = 0, coord_t srcy = 0, coord_t srcw = 0, coord_t srch = 0, float scale = 0)
+    {
       coord_t bmpw = bmp->width();
       coord_t bmph = bmp->height();
 
@@ -481,64 +545,6 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
           }
         }
       }
-    }
-
-    template<class T>
-    void drawScaledBitmap(const T * bitmap, coord_t x, coord_t y, coord_t w, coord_t h)
-    {
-      if (bitmap) {
-        float vscale = float(h) / bitmap->height();
-        float hscale = float(w) / bitmap->width();
-        float scale = vscale < hscale ? vscale : hscale;
-
-        int xshift = (w - (bitmap->width() * scale)) / 2;
-        int yshift = (h - (bitmap->height() * scale)) / 2;
-        drawBitmap(x + xshift, y + yshift, bitmap, 0, 0, 0, 0, scale);
-      }
-    }
-
-    BitmapBuffer * horizontalFlip() const;
-
-    BitmapBuffer * verticalFlip() const;
-
-    BitmapBuffer * invertMask() const;
-
-  protected:
-    static BitmapBuffer * load_bmp(const char * filename);
-    static BitmapBuffer * load_stb(const char * filename);
-
-    inline bool applyClippingRect(coord_t & x, coord_t & y, coord_t & w, coord_t & h) const
-    {
-      if (h < 0) {
-        y += h;
-        h = -h;
-      }
-
-      if (w < 0) {
-        x += w;
-        w = -w;
-      }
-
-      if (x >= xmax || y >= ymax)
-        return false;
-
-      if (y < ymin) {
-        h += y - ymin;
-        y = ymin;
-      }
-
-      if (x < xmin) {
-        w += x - xmin;
-        x = xmin;
-      }
-
-      if (y + h > ymax)
-        h = ymax - y;
-
-      if (x + w > xmax)
-        w = xmax - x;
-
-      return data && h > 0 && w > 0;
     }
 
     uint8_t drawChar(coord_t x, coord_t y, const uint8_t * font, const uint16_t * spec, unsigned int index, LcdFlags flags);

--- a/src/bitmapbuffer.h
+++ b/src/bitmapbuffer.h
@@ -314,9 +314,9 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       drawAlphaPixelAbs(x, y, opacity, value);
     }
 
-    void drawHorizontalLine(coord_t x, coord_t y, coord_t w, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
+    void drawHorizontalLine(coord_t x, coord_t y, coord_t w, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = 0);
 
-    void drawVerticalLine(coord_t x, coord_t y, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
+    void drawVerticalLine(coord_t x, coord_t y, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = 0);
 
     void drawLine(coord_t x1, coord_t y1, coord_t x2, coord_t y2, uint8_t pat, LcdFlags att);
 
@@ -330,7 +330,7 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       drawSolidFilledRect(x, y, 1, h, flags);
     }
 
-    void drawRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t thickness = 1, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
+    void drawRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t thickness = 1, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = 0);
 
     inline void drawSolidRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t thickness = 1, LcdFlags flags = 0)
     {
@@ -342,7 +342,7 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
 
     void drawSolidFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, LcdFlags flags = 0);
 
-    void drawFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
+    void drawFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = 0);
 
     void invertRect(coord_t x, coord_t y, coord_t w, coord_t h, LcdFlags flags = 0);
 

--- a/src/bitmapbuffer.h
+++ b/src/bitmapbuffer.h
@@ -314,9 +314,9 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       drawAlphaPixelAbs(x, y, opacity, value);
     }
 
-    void drawHorizontalLine(coord_t x, coord_t y, coord_t w, uint8_t pat = SOLID, LcdFlags flags = 0);
+    void drawHorizontalLine(coord_t x, coord_t y, coord_t w, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
 
-    void drawVerticalLine(coord_t x, coord_t y, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0);
+    void drawVerticalLine(coord_t x, coord_t y, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
 
     void drawLine(coord_t x1, coord_t y1, coord_t x2, coord_t y2, uint8_t pat, LcdFlags att);
 
@@ -330,7 +330,7 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       drawSolidFilledRect(x, y, 1, h, flags);
     }
 
-    void drawRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t thickness = 1, uint8_t pat = SOLID, LcdFlags flags = 0);
+    void drawRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t thickness = 1, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
 
     inline void drawSolidRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t thickness = 1, LcdFlags flags = 0)
     {
@@ -342,7 +342,7 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
 
     void drawSolidFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, LcdFlags flags = 0);
 
-    void drawFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0);
+    void drawFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t pat = SOLID, LcdFlags flags = 0, uint8_t opacity = OPACITY_MAX);
 
     void invertRect(coord_t x, coord_t y, coord_t w, coord_t h, LcdFlags flags = 0);
 
@@ -587,7 +587,7 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
       drawAlphaPixel(p, opacity, color);
     }
 
-    void drawHorizontalLineAbs(coord_t x, coord_t y, coord_t w, uint8_t pat, LcdFlags flags);
+    void drawHorizontalLineAbs(coord_t x, coord_t y, coord_t w, uint8_t pat, LcdFlags flags, uint8_t opacity);
 };
 
 extern BitmapBuffer * lcd;

--- a/src/coloredit.cpp
+++ b/src/coloredit.cpp
@@ -41,19 +41,18 @@ class ColorBox: public Window {
 
     void paint(BitmapBuffer * dc) override
     {
-      lcdSetColor(color);
       dc->drawSolidFilledRect(0, 0, width(), height(), DEFAULT_COLOR);
-      dc->drawSolidFilledRect(1, 1, width() - 2, height() - 2, CUSTOM_COLOR);
+      dc->drawSolidFilledRect(1, 1, width() - 2, height() - 2, color << 16);
     }
 
-    void setColor(LcdFlags value)
+    void setColor(pixel_t value)
     {
       color = value;
       invalidate();
     }
 
   protected:
-    LcdFlags color;
+    pixel_t color;
 };
 
 ColorEdit::ColorEdit(FormGroup * parent, const rect_t & rect, std::function<uint16_t()> getValue, std::function<void(uint16_t)> setValue):

--- a/src/libopenui_defines.h
+++ b/src/libopenui_defines.h
@@ -83,5 +83,4 @@
 #define COLOR2FLAGS(color)             LcdFlags(unsigned(color) << 16u)
 #define COLOR_VAL(flags)               ((flags) >> 16u)
 #define COLOR_MASK(flags)              ((flags) & 0xFFFF0000u)
-#define COLOR(index)                   (lcdColorTable[ unsigned(index) & 0xFF ] << 16u)
 

--- a/src/libopenui_defines.h
+++ b/src/libopenui_defines.h
@@ -75,31 +75,13 @@
   (((color) & 0x001F) << 3)
 
 #define OPACITY_MAX                    0x0Fu
-#define OPACITY(value)                 ((value) << 24u)
+#define OPACITY(value)                 ((value) & OPACITY_MAX)
 
 #define RGB(r, g, b)                   (uint16_t)((((r) & 0xF8) << 8) + (((g) & 0xFC) << 3) + (((b) & 0xF8) >> 3))
 #define ARGB(a, r, g, b)               (uint16_t)((((a) & 0xF0) << 8) + (((r) & 0xF0) << 4) + (((g) & 0xF0) << 0) + (((b) & 0xF0) >> 4))
 
-#define COLOR(index)                   LcdFlags(unsigned(index) << 16u)
-#define COLOR_IDX(flags)               uint8_t((flags) >> 16u)
+#define COLOR2FLAGS(color)             LcdFlags(unsigned(color) << 16u)
+#define COLOR_VAL(flags)               ((flags) >> 16u)
 #define COLOR_MASK(flags)              ((flags) & 0xFFFF0000u)
-
-#define DEFAULT_COLOR                  COLOR(DEFAULT_COLOR_INDEX)
-#define DEFAULT_BGCOLOR                COLOR(DEFAULT_BGCOLOR_INDEX)
-#define FOCUS_COLOR                    COLOR(FOCUS_COLOR_INDEX)
-#define FOCUS_BGCOLOR                  COLOR(FOCUS_BGCOLOR_INDEX)
-#define DISABLE_COLOR                  COLOR(DISABLE_COLOR_INDEX)
-#define HIGHLIGHT_COLOR                COLOR(HIGHLIGHT_COLOR_INDEX)
-#define CHECKBOX_COLOR                 COLOR(CHECKBOX_COLOR_INDEX)
-#define SCROLLBAR_COLOR                COLOR(SCROLLBAR_COLOR_INDEX)
-#define MENU_COLOR                     COLOR(MENU_COLOR_INDEX)
-#define MENU_BGCOLOR                   COLOR(MENU_BGCOLOR_INDEX)
-#define MENU_TITLE_BGCOLOR             COLOR(MENU_TITLE_BGCOLOR_INDEX)
-#define MENU_LINE_COLOR                COLOR(MENU_LINE_COLOR_INDEX)
-#define MENU_HIGHLIGHT_COLOR           COLOR(MENU_HIGHLIGHT_COLOR_INDEX)
-#define MENU_HIGHLIGHT_BGCOLOR         COLOR(MENU_HIGHLIGHT_BGCOLOR_INDEX)
-#define OVERLAY_COLOR                  COLOR(OVERLAY_COLOR_INDEX)
-#define TABLE_BGCOLOR                  COLOR(TABLE_BGCOLOR_INDEX)
-#define TABLE_HEADER_BGCOLOR           COLOR(TABLE_HEADER_BGCOLOR_INDEX)
-#define CUSTOM_COLOR                   COLOR(CUSTOM_COLOR_INDEX)
+#define COLOR(index)                   (lcdColorTable[ unsigned(index) & 0xFF ] << 16u)
 

--- a/src/libopenui_depends.h
+++ b/src/libopenui_depends.h
@@ -30,3 +30,25 @@ void onKeyError();
 void killEvents(event_t event);
 event_t getWindowEvent();
 
+//
+// These colors MUST be defined
+//
+
+// #define DEFAULT_COLOR                  
+// #define DEFAULT_BGCOLOR                
+// #define FOCUS_COLOR                    
+// #define FOCUS_BGCOLOR                  
+// #define DISABLE_COLOR                  
+// #define HIGHLIGHT_COLOR                
+// #define CHECKBOX_COLOR                 
+// #define SCROLLBAR_COLOR                
+// #define MENU_COLOR                     
+// #define MENU_BGCOLOR                   
+// #define MENU_TITLE_BGCOLOR             
+// #define MENU_LINE_COLOR                
+// #define MENU_HIGHLIGHT_COLOR           
+// #define MENU_HIGHLIGHT_BGCOLOR         
+// #define OVERLAY_COLOR                  
+// #define TABLE_BGCOLOR                  
+// #define TABLE_HEADER_BGCOLOR           
+// #define CUSTOM_COLOR                   

--- a/src/libopenui_depends.h
+++ b/src/libopenui_depends.h
@@ -26,6 +26,7 @@ void lcdNextLayer();
 uint16_t* lcdGetScratchBuffer();
 void DMACopyBitmap(uint16_t * dest, uint16_t destw, uint16_t desth, uint16_t x, uint16_t y, const uint16_t * src, uint16_t srcw, uint16_t srch, uint16_t srcx, uint16_t srcy, uint16_t w, uint16_t h);
 void DMACopyAlphaBitmap(uint16_t * dest, uint16_t destw, uint16_t desth, uint16_t x, uint16_t y, const uint16_t * src, uint16_t srcw, uint16_t srch, uint16_t srcx, uint16_t srcy, uint16_t w, uint16_t h);
+void DMACopyAlphaMask(uint16_t * dest, uint16_t destw, uint16_t desth, uint16_t x, uint16_t y, const uint8_t * src, uint16_t srcw, uint16_t srch, uint16_t srcx, uint16_t srcy, uint16_t w, uint16_t h, uint16_t bg_color);
 void onKeyPress();
 void onKeyError();
 void killEvents(event_t event);

--- a/src/libopenui_depends.h
+++ b/src/libopenui_depends.h
@@ -23,6 +23,7 @@
 #include "libopenui_config.h"
 
 void lcdNextLayer();
+uint16_t* lcdGetScratchBuffer();
 void DMACopyBitmap(uint16_t * dest, uint16_t destw, uint16_t desth, uint16_t x, uint16_t y, const uint16_t * src, uint16_t srcw, uint16_t srch, uint16_t srcx, uint16_t srcy, uint16_t w, uint16_t h);
 void DMACopyAlphaBitmap(uint16_t * dest, uint16_t destw, uint16_t desth, uint16_t x, uint16_t y, const uint16_t * src, uint16_t srcw, uint16_t srch, uint16_t srcx, uint16_t srcy, uint16_t w, uint16_t h);
 void onKeyPress();

--- a/src/libopenui_globals.cpp
+++ b/src/libopenui_globals.cpp
@@ -19,5 +19,3 @@
 
 #include "libopenui_globals.h"
 
-uint16_t lcdColorTable[LCD_COLOR_COUNT];
-

--- a/src/libopenui_globals.h
+++ b/src/libopenui_globals.h
@@ -22,12 +22,6 @@
 #include <inttypes.h>
 #include "libopenui_config.h"
 
-extern uint16_t lcdColorTable[LCD_COLOR_COUNT];
 extern const uint16_t * const fontspecsTable[FONTS_COUNT];
 extern const uint8_t * fontsTable[FONTS_COUNT];
-
-inline void lcdSetColor(uint16_t color)
-{
-  lcdColorTable[CUSTOM_COLOR_INDEX] = color;
-}
 

--- a/src/modal_window.cpp
+++ b/src/modal_window.cpp
@@ -41,7 +41,7 @@ void ModalWindow::deleteLater(bool detach, bool trash)
 
 void ModalWindow::paint(BitmapBuffer * dc)
 {
-  dc->drawFilledRect(0, 0, width(), height(), SOLID, OVERLAY_COLOR | OPACITY(5));
+  dc->drawFilledRect(0, 0, width(), height(), SOLID, OVERLAY_COLOR, OPACITY(5));
 }
 
 void ModalWindowContent::paint(BitmapBuffer * dc)

--- a/tools/encode-bitmap.py
+++ b/tools/encode-bitmap.py
@@ -114,8 +114,7 @@ class ImageEncoder:
         for y in range(height):
             for x in range(width):
                 value = self.get_pixel(image, x, y)
-                value = 0x0F - round(value / 16)
-                value = max(0x00, min(0x0F, value))
+                value = 0xFF - value
                 self.encode_byte(value)
             self.f.write("\n")
         self.encode_end()


### PR DESCRIPTION
**warning:** this PR is required for opentx/opentx#8468

As the displays libopenui works with understand only directly given colors (no palette involved), it is logical to pass directly colors in the same format as the BitmapBuffer. 

Pros:
- avoids passing a color table to libopenui
- not limited to the colors in the color table
- opens the way for real ARGB4444 in the future.

Changes:
- moved opacity into a separate parameter and
- use true color instead of palette index

Old `LcdFlags` format:
```
xxxx xxxx xxxx xxxx
xxxx .... .... ....  -> 8 bit opacity
.... xxxx .... ....  -> 16 bit color left shifted by 16 bit(RGB565 for now)
.... .... xxxx xxxx  -> other flags
```

New `LcdFlags` format:
```
xxxx xxxx xxxx xxxx
xxxx xxxx .... ....  -> 16 bit color left shifted by 16 bit(RGB565 for now)
.... .... xxxx xxxx  -> other flags
```